### PR TITLE
Adding object-fit on blog header image

### DIFF
--- a/src/components/blogPost.css
+++ b/src/components/blogPost.css
@@ -8,6 +8,7 @@
 }
 
 .blogPost__headerImage {
+  object-fit: cover;
   width: 100%;
   height: 340px;
   border-bottom: 2px solid #000;


### PR DESCRIPTION
images were not sized correctly. Added `object-fit: cover;`

## Before 
![image](https://user-images.githubusercontent.com/32040951/79257147-811cf780-7e89-11ea-8dee-ef7bd4768a31.png)

## After
![image](https://user-images.githubusercontent.com/32040951/79257168-8aa65f80-7e89-11ea-9c28-0e7e98e943e5.png)

