### PR TITLE
fix: Update navbar width to avoid overflow-x

### DIFF
--- a/src/components/nav.css
+++ b/src/components/nav.css
@@ -1,6 +1,6 @@
 .nav {
   border: 1px solid #979797;
-  width: 100vw;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Description

In widescreen take place a overflow-x. 

![image](https://user-images.githubusercontent.com/22948756/79265074-89623c00-7e63-11ea-8831-2c9817a0c497.png)

This is because it have assigned `width: 100vw`. After change it to `width: 100%` looks like:

![image](https://user-images.githubusercontent.com/22948756/79265345-f2e24a80-7e63-11ea-8ba3-a20aa1e1290c.png)
