### PR TITLE
Removed trailing 'I am a Software...' 

### DIFF
--- a/src/components/aboutMe.js
+++ b/src/components/aboutMe.js
@@ -16,10 +16,6 @@ const AboutMe = () => (
       In my spare time I have a podcast with two of my friends, I blog, and I
       create technical courses.
     </p>
-    <p>
-      I am a Software Engineer based out of Karlsruhe, Germany. Born and raised
-      in Upstate New York, I sold everything and moved to Europe two years ago.
-    </p>
     <Link className="learn-more" to="/about">
       Learn more
     </Link>


### PR DESCRIPTION
You got the duplicate where it was right next to itself - but the "I am a Software..." section was at the beginning and end.

I took out the one at the end (it seemed to read better that way versus removing the one at the beginning).